### PR TITLE
Remove numpy

### DIFF
--- a/ports/llvm/0010-remove-numpy.patch
+++ b/ports/llvm/0010-remove-numpy.patch
@@ -1,0 +1,25 @@
+From 80300a7f4533fdfc75ec60b0d1dc1c5d5a6b9e3c Mon Sep 17 00:00:00 2001
+From: Ankur Verma <ankurv@microsoft.com>
+Date: Fri, 14 Jul 2023 09:45:22 -0700
+Subject: [PATCH] remove_numpy
+
+---
+ mlir/cmake/modules/MLIRDetectPythonEnv.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mlir/cmake/modules/MLIRDetectPythonEnv.cmake b/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
+index 9c8966591514..35c94f0d1acc 100644
+--- a/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
++++ b/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
+@@ -26,7 +26,7 @@ macro(mlir_configure_python_dev_packages)
+   set(_python_development_component Development.Module)
+ 
+   find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION}
+-    COMPONENTS Interpreter ${_python_development_component} NumPy REQUIRED)
++    COMPONENTS Interpreter ${_python_development_component} REQUIRED)
+   unset(_python_development_component)
+   message(STATUS "Found python include dirs: ${Python3_INCLUDE_DIRS}")
+   message(STATUS "Found python libraries: ${Python3_LIBRARIES}")
+-- 
+2.41.0.windows.2
+

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         0007-Fix-install-bolt.patch
         0008-llvm_assert.patch
         0009-disable-libomp-aliases.patch
+        0010-remove-numpy.patch
 )
 
 vcpkg_check_features(
@@ -148,7 +149,7 @@ endif()
 if("mlir" IN_LIST FEATURES)
     list(APPEND LLVM_ENABLE_PROJECTS "mlir")
     if("enable-mlir-python-bindings" IN_LIST FEATURES)
-        x_vcpkg_get_python_packages(PYTHON_VERSION 3 PACKAGES numpy OUT_PYTHON_VAR PYTHON3)
+        vcpkg_find_acquire_program(PYTHON3)
         list(APPEND FEATURE_OPTIONS
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON
             -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON3}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
